### PR TITLE
feat: updating with new helm unittest snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ noDocTemplates:
 
 #### Environment based document skips
 
+**This is deprecated now with >0.5.0 helm unittest you will want to update your test.sh scripts to ensure that no new snap files are created instead**
+
 More commonly, you might find yourself wanting to say that certain environments are probably missing templates.  This
 could happen because you have a cost cutting measure in some environments over others, or different tooling.  This type of
 thing is up to you to ultimately pattern (and probably add to your `snapshots-template.yaml`), but the following is a naive
@@ -179,7 +181,7 @@ tests:
         count: 0
         {{- end }}
     {{- end }}
-    {{- if not $hasClusterEntry }}
+    {{- if not $noSnapshot }}
       - matchSnapshot: {}
     {{- end }}
 ---

--- a/bin/helm/make-snapshots.sh
+++ b/bin/helm/make-snapshots.sh
@@ -60,15 +60,7 @@ tests:
     set:
       env: {{ \$env }}
     asserts:
-    {{- /*
-      If we have no documents snapshot doesn't handle that well
-    */}}
-    {{- if has \"YAML_NAME\" $.Values.noDocTemplates }}
-      - hasDocuments:
-        count: 0 
-    {{- else }}
       - matchSnapshot: {}
-    {{- end }}
 ---
 {{- end }}
 "

--- a/bin/helm/setup-tests.sh
+++ b/bin/helm/setup-tests.sh
@@ -126,26 +126,64 @@ do
     shift
 done
 
-echo "Checking to see if there are missing snapshots..."
+echo \"Checking to see if helm unittest is correct version...\"
+unittestVersion=\$(helm plugin list | grep unittest | awk -F ' ' '{print \$2}')
+IFS='.' read -ra versionComponents <<< "\$unittestVersion"
+major=\${versionComponents[0]}
+minor=\${versionComponents[1]}
+patch=\${versionComponents[2]}
+if [[ \$minor -lt 5 ]]; then
+    echo \"Must have helm unittest >=0.5.1.  Please run \`helm plugin update unittest\`\"
+    exit 1
+fi
+if [[ \$minor -eq 5 ]]; then
+    if [[ \$patch -lt 1 ]]; then
+    echo \"Must have helm unittest >=0.5.1.  Please run \`helm plugin update unittest\`\"
+    exit 1
+    fi
+fi
+
+echo \"Checking to see if there are missing snapshots...\"
 set +e
 # Additional custom test scripts - maybe verifying prometheus config, etc.
 createdFiles=\$(\$BASEDIR/$relPath${BASEDIR/.\//}/make-snapshots.sh \$BASEDIR)
-if [[ "$?" != "0" ]]; then
-    echo "Failure calling make-snapshots.sh:\n\$createdFiles"
+if [[ \"\$?\" != \"0\" ]]; then
+    echo \"Failure calling make-snapshots.sh:\n\$createdFiles\"
     exit $?
 fi
 set -e
 
-if [[ "\$createdFiles" == *\"creating snapshot file:\"* ]]; then
-    echo "There were uncreated snapshot files!  Please re-run tests"
+if [[ \"\$createdFiles\" == *\"creating snapshot file:\"* ]]; then
+    echo \"There were uncreated snapshot files!  Please re-run tests\"
     echo -e "\$createdFiles"
     exit 1
 fi
 
-echo "Running Unit tests..."
+if [[ \$createdFiles == *\"creating snapshot file:\"* ]]; then
+    echo \"There were uncreated snapshot files! Please re-run tests\"
+    echo -e \"\$createdFiles\"
+    exit 1
+fi
+
+echo \"Running Unit tests...\"
+
+if [ -z \"\$updateSnapshotArg\" ]; then
+    currentSnaps=\$(find \$BASEDIR/tests-chart/templates/__snapshot__ -type f)
+fi
 
 # Run all the tests in the ./tests folder
 helm unittest \${updateSnapshotArg} --chart-tests-path tests-chart \$BASEDIR
+
+if [ -z \"\$updateSnapshotArg\" ]; then
+    postSnaps=\$(find \$BASEDIR/tests-chart/templates/__snapshot__ -type f)
+    newFiles=\$(diff - _compare <<< \"\$currentSnaps\" & echo \"\$postSnaps\" > _compare)
+    rm _compare
+    if [ ! -z \"\$newFiles\" ]; then
+        echo \"New Snapshot files were generated!  These must be committed for testing to pass\"
+        echo -e \"\$newFiles\"
+        exit 3
+    fi
+fi
 " > $workingDir/test.sh
 chmod 755 $workingDir/test.sh
 else

--- a/example-chart2/test.sh
+++ b/example-chart2/test.sh
@@ -1,10 +1,8 @@
 
 #!/bin/bash -e
 
-BASEDIR=$(dirname $0)
-
 help="#########################################
-# Test shell script for 
+# Test shell script for janus-workflows
 #
 # params:
 #   --update-snapshots - if specified we update snapshots instead of evaluating
@@ -32,10 +30,27 @@ do
     shift
 done
 
+echo "Checking to see if correct helm unittest is correct version..."
+unittestVersion=$(helm plugin list | grep unittest | awk -F ' ' '{print $2}')
+IFS='.' read -ra versionComponents <<< "$unittestVersion"
+major=${versionComponents[0]}
+minor=${versionComponents[1]}
+patch=${versionComponents[2]}
+if [[ $minor -lt 5 ]]; then
+    echo "Must have helm unittest >=0.5.1.  Please run \`helm plugin update unittest\`"
+    exit 1
+fi
+if [[ $minor -eq 5 ]]; then
+    if [[ $patch -lt 1 ]]; then
+    echo "Must have helm unittest >=0.5.1.  Please run \`helm plugin update unittest\`"
+    exit 1
+    fi
+fi
+
 echo Checking to see if there are missing snapshots...
 set +e
 # Additional custom test scripts - maybe verifying prometheus config, etc.
-createdFiles=$($BASEDIR/../bin/helm/make-snapshots.sh $BASEDIR)
+createdFiles=$($BASEDIR/../../bin/helm/make-snapshots.sh $BASEDIR)
 if [[ 0 != 0 ]]; then
     echo Failure calling make-snapshots.sh:n$createdFiles
     exit 0
@@ -50,6 +65,20 @@ fi
 
 echo Running Unit tests...
 
+if [ -z "$updateSnapshotArg" ]; then
+    currentSnaps=$(find $BASEDIR/tests-chart/templates/__snapshot__ -type f)
+fi
+
 # Run all the tests in the ./tests folder
 helm unittest ${updateSnapshotArg} --chart-tests-path tests-chart $BASEDIR
 
+if [ -z "$updateSnapshotArg" ]; then
+    postSnaps=$(find $BASEDIR/tests-chart/templates/__snapshot__ -type f)
+    newFiles=$(diff - _compare <<< "$currentSnaps" & echo "$postSnaps" > _compare)
+    rm _compare
+    if [ ! -z "$newFiles" ]; then
+        echo "New Snapshot files were generated!  These must be committed for testing to pass"
+        echo -e "$newFiles"
+        exit 3
+    fi
+fi


### PR DESCRIPTION
# Summary

This pr updates the test.sh scripts to handle the new functionality of helm unittest not failing when there are 0 charts created for a file.  It also adds adittional scripting to the test.sh file to fail if new snapshots are created to avoid the failure mode of a PR submitter never committing a snapshot for something.